### PR TITLE
arm64: fix build issues and assert in arm64 builds

### DIFF
--- a/Samples/ARM32-FirmwareTPM/optee_ta/fTPM/sub.mk
+++ b/Samples/ARM32-FirmwareTPM/optee_ta/fTPM/sub.mk
@@ -3,7 +3,13 @@ NOWERROR ?= 1
 CFG_TA_DEBUG ?= 1
 CFG_TEE_TA_LOG_LEVEL ?= 1
 
-cflags-y += -DTHIRTY_TWO_BIT -DCFG_TEE_TA_LOG_LEVEL=$(CFG_TEE_TA_LOG_LEVEL) -D_ARM_ -w -Wno-strict-prototypes -mcpu=$(TA_CPU) -fstack-protector -Wstack-protector -mno-unaligned-access
+cflags-y += -DTHIRTY_TWO_BIT -DCFG_TEE_TA_LOG_LEVEL=$(CFG_TEE_TA_LOG_LEVEL) -D_ARM_ -w -Wno-strict-prototypes -mcpu=$(TA_CPU) -fstack-protector -Wstack-protector
+
+ifeq ($(CFG_ARM64_ta_arm64),y)
+cflags-y += -mstrict-align
+else
+cflags-y += -mno-unaligned-access
+endif
 
 ifeq ($(CFG_TA_DEBUG),y)
 cflags-y += -DfTPMDebug=1

--- a/TPMCmd/tpm/src/support/TpmSizeChecks.c
+++ b/TPMCmd/tpm/src/support/TpmSizeChecks.c
@@ -100,9 +100,9 @@ TpmSizeChecks(
         // round required size up to nearest 8 byte boundary.
         biggestContext = 8 * ((biggestContext + 7) / 8);
 
-        if(MAX_CONTEXT_SIZE != biggestContext)
+        if(MAX_CONTEXT_SIZE < biggestContext)
         {
-            printf("MAX_CONTEXT_SIZE should be changed to %d\n", biggestContext);
+            printf("MAX_CONTEXT_SIZE too small, should be changed to %d\n", biggestContext);
             pAssert(0);
         }
     }


### PR DESCRIPTION
- use -mstrict-align instead of -mno_unaligned_access for ARM64 builds
- disable assert when MAX_CONTENT_SIZE is larger than calculated biggestContext value